### PR TITLE
[smarc_gazebo_plugins] Added a first version of a more realistic sonar sensor

### DIFF
--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Eigen3 REQUIRED)
 find_package(Protobuf REQUIRED)
+#find_package(OGRE REQUIRED)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
@@ -137,6 +138,9 @@ add_library(underwater_sonar_plugin
   src/UnderwaterSonarPlugin.cc
 )
 
+add_library(register_underwater_sonar_sensor
+  src/RegisterUnderwaterSonarSensor.cc
+)
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
@@ -167,6 +171,10 @@ target_link_libraries(underwater_sonar_plugin
   ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
 )
 
+target_link_libraries(register_underwater_sonar_sensor
+  underwater_sonar_sensor
+  ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
+)
 #############
 ## Install ##
 #############
@@ -185,6 +193,7 @@ target_link_libraries(underwater_sonar_plugin
 install(TARGETS
   underwater_sonar_sensor
   underwater_sonar_plugin
+  register_underwater_sonar_sensor
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
@@ -130,6 +130,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 link_directories(${EIGEN3_LIBRARY_DIRS} ${GAZEBO_LIBRARY_DIRS})
 
 ## Declare a C++ library
+add_library(semantic_multi_ray_shape
+  src/SemanticMultiRayShape.cc
+)
+
 add_library(underwater_sonar_sensor
   src/UnderwaterSonarSensor.cc
 )
@@ -162,7 +166,12 @@ add_library(register_underwater_sonar_sensor
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
+target_link_libraries(semantic_multi_ray_shape
+  ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
+)
+
 target_link_libraries(underwater_sonar_sensor
+  semantic_multi_ray_shape
   ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
 )
 
@@ -191,6 +200,7 @@ target_link_libraries(register_underwater_sonar_sensor
 
 ## Mark executables and/or libraries for installation
 install(TARGETS
+  semantic_multi_ray_shape
   underwater_sonar_sensor
   underwater_sonar_plugin
   register_underwater_sonar_sensor

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
@@ -114,7 +114,7 @@ catkin_package(
                ${GAZEBO_INCLUDE_DIRS}
                ${GAZEBO_MSG_INCLUDE_DIRS}
                ${EIGEN3_INCLUDE_DIRS}
-  LIBRARIES underwater_sonar_plugin
+  LIBRARIES underwater_sonar_sensor underwater_sonar_plugin
   DEPENDS gazebo
 )
 
@@ -129,6 +129,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 link_directories(${EIGEN3_LIBRARY_DIRS} ${GAZEBO_LIBRARY_DIRS})
 
 ## Declare a C++ library
+add_library(underwater_sonar_sensor
+  src/UnderwaterSonarSensor.cc
+)
+
 add_library(underwater_sonar_plugin
   src/UnderwaterSonarPlugin.cc
 )
@@ -154,7 +158,12 @@ add_library(underwater_sonar_plugin
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
+target_link_libraries(underwater_sonar_sensor
+  ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
+)
+
 target_link_libraries(underwater_sonar_plugin
+  underwater_sonar_sensor
   ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
 )
 
@@ -174,6 +183,7 @@ target_link_libraries(underwater_sonar_plugin
 
 ## Mark executables and/or libraries for installation
 install(TARGETS
+  underwater_sonar_sensor
   underwater_sonar_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/CMakeLists.txt
@@ -1,0 +1,212 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(smarc_gazebo_plugins)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+find_package(gazebo REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+find_package(Eigen3 REQUIRED)
+find_package(Protobuf REQUIRED)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+               ${CMAKE_CURRENT_BINARY_DIR} # for generated messages
+			   #${PROJECT_BINARY_DIR}/msgs
+               ${Boost_INCLUDE_DIR}
+               ${catkin_INCLUDE_DIRS}
+               ${GAZEBO_INCLUDE_DIRS}
+               ${GAZEBO_MSG_INCLUDE_DIRS}
+               ${EIGEN3_INCLUDE_DIRS}
+  LIBRARIES underwater_sonar_plugin
+  DEPENDS gazebo
+)
+
+include_directories(${PROJECT_SOURCE_DIR}/include
+                    ${CMAKE_CURRENT_BINARY_DIR} # for generated messages
+                    ${Boost_INCLUDE_DIR}
+                    ${catkin_INCLUDE_DIRS}
+                    ${GAZEBO_INCLUDE_DIRS}
+                    ${GAZEBO_MSG_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS})
+
+link_directories(${EIGEN3_LIBRARY_DIRS} ${GAZEBO_LIBRARY_DIRS})
+
+## Declare a C++ library
+add_library(underwater_sonar_plugin
+  src/UnderwaterSonarPlugin.cc
+)
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/smarc_gazebo_plugins_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(underwater_sonar_plugin
+  ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS
+  underwater_sonar_plugin
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.hh"
+  PATTERN "*~" EXCLUDE
+)
+
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN ".hh"
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_smarc_gazebo_plugins.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/SemanticMultiRayShape.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/SemanticMultiRayShape.hh
@@ -1,0 +1,37 @@
+#ifndef SEMANTIC_MULTIRAY_SHAPE_HH
+#define SEMANTIC_MULTIRAY_SHAPE_HH
+
+#include <gazebo/physics/MultiRayShape.hh>
+
+namespace gazebo
+{
+
+  //class MultiRayShape;
+
+  namespace physics {
+    
+    /// \class MultiRayShape MultiRayShape.hh physics/physics.hh
+    /// \brief Laser collision contains a set of ray-collisions,
+    /// structured to simulate a laser range scanner.
+    class SemanticMultiRayShape : public MultiRayShape
+    {
+      /// \brief Constructor.
+      /// \param[in] _parent Parent collision shape.
+      public: explicit SemanticMultiRayShape(CollisionPtr _parent);
+
+      /// \brief Destructor.
+      public: virtual ~SemanticMultiRayShape();
+
+      public: RayShapePtr GetRay(unsigned int _index);
+      
+	  public: static RayShapePtr StaticGetRay(MultiRayShapePtr _parent, unsigned int _index);
+
+    };
+
+    typedef boost::shared_ptr<SemanticMultiRayShape> SemanticMultiRayShapePtr;
+
+  }
+
+}
+
+#endif // SEMANTIC_MULTIRAY_SHAPE_HH

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
@@ -24,7 +24,7 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/sensors/SensorTypes.hh>
-//#include <gazebo/sensors/RaySensor.hh>
+#include <gazebo/sensors/RaySensor.hh>
 #include <smarc_gazebo_plugins/UnderwaterSonarSensor.hh>
 #include <gazebo/util/system.hh>
 
@@ -50,7 +50,7 @@ namespace gazebo
     protected: physics::WorldPtr world;
 
     /// \brief The parent sensor
-	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parentSensor;
+	private: std::shared_ptr<sensors::RaySensor> parentSensor;
 
     /// \brief The connection tied to UnderwaterSonarPlugin::OnNewLaserScans()
     private: event::ConnectionPtr newLaserScansConnection;

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
@@ -15,16 +15,17 @@
  *
 */
 /*
- * Desc: Ray Plugin
- * Author: Nate Koenig mod by John Hsu
+ * Desc: Underwater Sonar Plugin
+ * Author: Nate Koenig mod by John Hsu and Nils Bore
  */
 
-#ifndef _GAZEBO_RAY_PLUGIN_HH_
-#define _GAZEBO_RAY_PLUGIN_HH_
+#ifndef _GAZEBO_UNDERWATER_SONAR_PLUGIN_HH_
+#define _GAZEBO_UNDERWATER_SONAR_PLUGIN_HH_
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/sensors/SensorTypes.hh>
-#include <gazebo/sensors/RaySensor.hh>
+//#include <gazebo/sensors/RaySensor.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarSensor.hh>
 #include <gazebo/util/system.hh>
 
 namespace gazebo
@@ -49,10 +50,10 @@ namespace gazebo
     protected: physics::WorldPtr world;
 
     /// \brief The parent sensor
-    private: sensors::RaySensorPtr parentSensor;
+	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parentSensor;
 
     /// \brief The connection tied to UnderwaterSonarPlugin::OnNewLaserScans()
     private: event::ConnectionPtr newLaserScansConnection;
   };
 }
-#endif
+#endif // _GAZEBO_UNDERWATER_SONAR_PLUGIN_HH_

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
@@ -50,7 +50,7 @@ namespace gazebo
     protected: physics::WorldPtr world;
 
     /// \brief The parent sensor
-	private: std::shared_ptr<sensors::RaySensor> parentSensor;
+	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parentSensor;
 
     /// \brief The connection tied to UnderwaterSonarPlugin::OnNewLaserScans()
     private: event::ConnectionPtr newLaserScansConnection;

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarPlugin.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: Ray Plugin
+ * Author: Nate Koenig mod by John Hsu
+ */
+
+#ifndef _GAZEBO_RAY_PLUGIN_HH_
+#define _GAZEBO_RAY_PLUGIN_HH_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/sensors/RaySensor.hh>
+#include <gazebo/util/system.hh>
+
+namespace gazebo
+{
+  /// \brief A Ray Sensor Plugin
+  class GAZEBO_VISIBLE UnderwaterSonarPlugin : public SensorPlugin
+  {
+    /// \brief Constructor
+    public: UnderwaterSonarPlugin();
+
+    /// \brief Destructor
+    public: virtual ~UnderwaterSonarPlugin();
+
+    /// \brief Update callback
+    public: virtual void OnNewLaserScans();
+
+    /// \brief Load the plugin
+    /// \param take in SDF root element
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Pointer to parent
+    protected: physics::WorldPtr world;
+
+    /// \brief The parent sensor
+    private: sensors::RaySensorPtr parentSensor;
+
+    /// \brief The connection tied to UnderwaterSonarPlugin::OnNewLaserScans()
+    private: event::ConnectionPtr newLaserScansConnection;
+  };
+}
+#endif

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensor.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensor.hh
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _GAZEBO_UNDERWATER_SONAR_SENSOR_HH_
+#define _GAZEBO_UNDERWATER_SONAR_SENSOR_HH_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ignition/math/Angle.hh>
+
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/util/system.hh>
+
+namespace gazebo
+{
+  class OgreDynamicLines;
+  class Collision;
+  class MultiRayShape;
+
+  /// \ingroup gazebo_sensors
+  /// \brief Sensors namespace
+  namespace sensors
+  {
+    // Forward declare private data class.
+    class UnderwaterSonarSensorPrivate;
+
+    /// \addtogroup gazebo_sensors
+    /// \{
+
+    /// \class UnderwaterSonarSensor UnderwaterSonarSensor.hh sensors/sensors.hh
+    /// \brief Sensor with one or more rays.
+    ///
+    /// This sensor cast rays into the world, tests for intersections, and
+    /// reports the range to the nearest object.  It is used by ranging
+    /// sensor models (e.g., sonars and scanning laser range finders).
+    class GAZEBO_VISIBLE UnderwaterSonarSensor: public Sensor
+    {
+      /// \brief Constructor
+      public: UnderwaterSonarSensor();
+
+      /// \brief Destructor
+      public: virtual ~UnderwaterSonarSensor();
+
+      // Documentation inherited
+      public: virtual void Load(const std::string &_worldName);
+
+      // Documentation inherited
+      public: virtual void Init();
+
+      // Documentation inherited
+      protected: virtual bool UpdateImpl(const bool _force);
+
+      // Documentation inherited
+      protected: virtual void Fini();
+
+      // Documentation inherited
+      public: virtual std::string Topic() const;
+
+      /// \brief Get the minimum angle
+      /// \return The minimum angle object
+      public: ignition::math::Angle AngleMin() const;
+
+      /// \brief Get the maximum angle
+      /// \return the maximum angle object
+      public: ignition::math::Angle AngleMax() const;
+
+      /// \brief Get the angle in radians between each range
+      /// \return Resolution of the angle
+      /// \deprecated See AngleResolution()
+      public: double GetAngleResolution() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the angle in radians between each range
+      /// \return Resolution of the angle
+      public: double AngleResolution() const;
+
+      /// \brief Get the minimum range
+      /// \return The minimum range
+      /// \deprecated See RangeMin()
+      public: double GetRangeMin() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the minimum range
+      /// \return The minimum range
+      public: double RangeMin() const;
+
+      /// \brief Get the maximum range
+      /// \return The maximum range
+      /// \deprecated See RangeMax()
+      public: double GetRangeMax() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the maximum range
+      /// \return The maximum range
+      public: double RangeMax() const;
+
+      /// \brief Get the range resolution
+      /// \return Resolution of the range
+      /// \deprecated See RangeResolution()
+      public: double GetRangeResolution() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the range resolution
+      /// \return Resolution of the range
+      public: double RangeResolution() const;
+
+      /// \brief Get the ray count
+      /// \return The number of rays
+      /// \deprecated See RayCount()
+      public: int GetRayCount() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the ray count
+      /// \return The number of rays
+      public: int RayCount() const;
+
+      /// \brief Get the range count
+      /// \return The number of ranges
+      /// \deprecated See RangeCount
+      public: int GetRangeCount() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the range count
+      /// \return The number of ranges
+      public: int RangeCount() const;
+
+      /// \brief Get the vertical scan line count
+      /// \return The number of scan lines vertically
+      /// \deprecated See VerticalRayCount()
+      public: int GetVerticalRayCount() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the vertical scan line count
+      /// \return The number of scan lines vertically
+      public: int VerticalRayCount() const;
+
+      /// \brief Get the vertical scan line count
+      /// \return The number of scan lines vertically
+      /// \deprecated See VerticalRangeCount();
+      public: int GetVerticalRangeCount() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the vertical scan line count
+      /// \return The number of scan lines vertically
+      public: int VerticalRangeCount() const;
+
+      /// \brief Get the vertical scan bottom angle
+      /// \return The minimum angle of the scan block
+      public: ignition::math::Angle VerticalAngleMin() const;
+
+      /// \brief Get the vertical scan line top angle
+      /// \return The Maximum angle of the scan block
+      public: ignition::math::Angle VerticalAngleMax() const;
+
+      /// \brief Get the vertical angle in radians between each range
+      /// \return Resolution of the angle
+      /// \deprecated See VerticalAngleResolution()
+      public: double GetVerticalAngleResolution() const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get the vertical angle in radians between each range
+      /// \return Resolution of the angle
+      public: double VerticalAngleResolution() const;
+
+      /// \brief Get detected range for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index of specific ray
+      /// \return Returns RangeMax for no detection.
+      /// \deprecated See Range(unsigned int _index)
+      public: double GetRange(unsigned int _index) GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get detected range for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index of specific ray
+      /// \return Returns RangeMax for no detection.
+      public: double Range(const unsigned int _index) const;
+
+      /// \brief Get all the ranges
+      /// \param _ranges A vector that will contain all the range data
+      /// \deprecated See Ranges(std::vector<double> &_ranges)
+      public: void GetRanges(std::vector<double> &_ranges)
+              GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get all the ranges
+      /// \param[out] _ranges A vector that will contain all the range data
+      public: void Ranges(std::vector<double> &_ranges) const;
+
+      /// \brief Get detected retro (intensity) value for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index of specific ray
+      /// \return Retro (intensity) value for ray
+      /// \deprecated See Retro(unsigned int _index)
+      public: double GetRetro(unsigned int _index) GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get detected retro (intensity) value for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index of specific ray
+      /// \return Retro (intensity) value for ray
+      public: double Retro(const unsigned int _index) const;
+
+      /// \brief Get detected fiducial value for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index value of specific ray
+      /// \return Fiducial value
+      /// \deprecated See Fiducial(unsigned int _index)
+      public: int GetFiducial(unsigned int _index) GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Get detected fiducial value for a ray.
+      ///         Warning: If you are accessing all the ray data in a loop
+      ///         it's possible that the Ray will update in the middle of
+      ///         your access loop. This means some data will come from one
+      ///         scan, and some from another scan. You can solve this
+      ///         problem by using SetActive(false) <your accessor loop>
+      ///         SetActive(true).
+      /// \param[in] _index Index value of specific ray
+      /// \return Fiducial value
+      public: int Fiducial(const unsigned int _index) const;
+
+      /// \brief Returns a pointer to the internal physics::MultiRayShape
+      /// \return Pointer to ray shape
+      /// \deprecated See LaserShape()
+      public: physics::MultiRayShapePtr GetLaserShape()
+              const GAZEBO_DEPRECATED(7.0);
+
+      /// \brief Returns a pointer to the internal physics::MultiRayShape
+      /// \return Pointer to ray shape
+      public: physics::MultiRayShapePtr LaserShape() const;
+
+      // Documentation inherited
+      public: virtual bool IsActive() const;
+
+      /// \internal
+      /// \brief Private data pointer.
+      private: std::unique_ptr<UnderwaterSonarSensorPrivate> dataPtr;
+    };
+    /// \}
+  }
+}
+
+#endif // _GAZEBO_UNDERWATER_SONAR_SENSOR_HH_

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensor.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensor.hh
@@ -26,6 +26,8 @@
 #include <gazebo/sensors/Sensor.hh>
 #include <gazebo/util/system.hh>
 
+void RegisterUnderwaterSonarSensor();
+
 namespace gazebo
 {
   class OgreDynamicLines;

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _GAZEBO_SENSORS_RAYSENSOR_PRIVATE_HH_
+#define _GAZEBO_SENSORS_RAYSENSOR_PRIVATE_HH_
+
+#include <mutex>
+
+#include "gazebo/msgs/msgs.hh"
+#include "gazebo/physics/PhysicsTypes.hh"
+#include "gazebo/transport/TransportTypes.hh"
+
+namespace gazebo
+{
+  namespace sensors
+  {
+    /// \internal
+    /// \brief Ray sensor private data.
+    class UnderwaterSonarSensorPrivate
+    {
+      /// \brief Laser collision pointer.
+      public: physics::CollisionPtr laserCollision;
+
+      /// \brief Multi ray shapre pointer.
+      public: physics::MultiRayShapePtr laserShape;
+
+      /// \brief Parent entity pointer
+      public: physics::EntityPtr parentEntity;
+
+      /// \brief Publisher for the scans
+      public: transport::PublisherPtr scanPub;
+
+      /// \brief Mutex to protect laserMsg
+      public: std::mutex mutex;
+
+      /// \brief Laser message.
+      public: msgs::LaserScanStamped laserMsg;
+    };
+  }
+}
+#endif

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/include/smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh
@@ -43,11 +43,17 @@ namespace gazebo
       /// \brief Publisher for the scans
       public: transport::PublisherPtr scanPub;
 
+      /// \brief Publisher for the entities
+      public: transport::PublisherPtr entityPub;
+			  //
       /// \brief Mutex to protect laserMsg
       public: std::mutex mutex;
 
       /// \brief Laser message.
       public: msgs::LaserScanStamped laserMsg;
+     
+      /// \brief Entity message
+	  public: msgs::GzString_V entityMsg;
     };
   }
 }

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/package.xml
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>smarc_gazebo_plugins</name>
+  <version>0.0.0</version>
+  <description>The smarc_gazebo_plugins package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/smarc_gazebo_plugins</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/RegisterUnderwaterSonarSensor.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/RegisterUnderwaterSonarSensor.cc
@@ -1,0 +1,32 @@
+#include <gazebo/gazebo.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarSensor.hh>
+
+namespace gazebo
+{
+  class RegisterUnderwaterSonarSensorPlugin : public SystemPlugin
+  {
+    /////////////////////////////////////////////
+    /// \brief Destructor
+    public: virtual ~RegisterUnderwaterSonarSensorPlugin()
+    {
+    }
+
+    /////////////////////////////////////////////
+    /// \brief Called after the plugin has been constructed.
+    public: void Load(int /*_argc*/, char ** /*_argv*/)
+    {
+		RegisterUnderwaterSonarSensor();
+		printf("Loaded the underwater sonar sensor!\n");
+    }
+
+    /////////////////////////////////////////////
+    // \brief Called once after Load
+    private: void Init()
+    {
+    }
+
+  };
+
+  // Register this plugin with the simulator
+  GZ_REGISTER_SYSTEM_PLUGIN(RegisterUnderwaterSonarSensorPlugin)
+}

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/SemanticMultiRayShape.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/SemanticMultiRayShape.cc
@@ -1,0 +1,24 @@
+#include <smarc_gazebo_plugins/SemanticMultiRayShape.hh>
+
+using namespace gazebo;
+using namespace physics;
+
+RayShapePtr SemanticMultiRayShape::StaticGetRay(MultiRayShapePtr _parent, unsigned int _index)
+{
+  return static_cast<SemanticMultiRayShape*>(_parent.get())->GetRay(_index);
+}
+
+RayShapePtr SemanticMultiRayShape::GetRay(unsigned int _index)
+{
+  return rays[_index];
+}
+
+SemanticMultiRayShape::SemanticMultiRayShape(CollisionPtr _parent) : MultiRayShape(_parent)
+{
+
+}
+
+SemanticMultiRayShape::~SemanticMultiRayShape()
+{
+
+}

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
@@ -45,7 +45,7 @@ void UnderwaterSonarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr /*_
 {
   // Get then name of the parent sensor
   this->parentSensor =
-    std::dynamic_pointer_cast<sensors::UnderwaterSonarSensor>(_parent);
+    std::dynamic_pointer_cast<sensors::RaySensor>(_parent);
 
   if (!this->parentSensor)
     gzthrow("UnderwaterSonarPlugin requires a Ray Sensor as its parent");

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
@@ -45,7 +45,7 @@ void UnderwaterSonarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr /*_
 {
   // Get then name of the parent sensor
   this->parentSensor =
-    std::dynamic_pointer_cast<sensors::RaySensor>(_parent);
+    std::dynamic_pointer_cast<sensors::UnderwaterSonarSensor>(_parent);
 
   if (!this->parentSensor)
     gzthrow("UnderwaterSonarPlugin requires a Ray Sensor as its parent");

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarPlugin.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <functional>
+
+#include <gazebo/physics/physics.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarPlugin.hh>
+
+using namespace gazebo;
+
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(UnderwaterSonarPlugin)
+
+/////////////////////////////////////////////////
+UnderwaterSonarPlugin::UnderwaterSonarPlugin()
+{
+}
+
+/////////////////////////////////////////////////
+UnderwaterSonarPlugin::~UnderwaterSonarPlugin()
+{
+  this->parentSensor->LaserShape()->DisconnectNewLaserScans(
+      this->newLaserScansConnection);
+  this->newLaserScansConnection.reset();
+
+  this->parentSensor.reset();
+  this->world.reset();
+}
+
+/////////////////////////////////////////////////
+void UnderwaterSonarPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr /*_sdf*/)
+{
+  // Get then name of the parent sensor
+  this->parentSensor =
+    std::dynamic_pointer_cast<sensors::RaySensor>(_parent);
+
+  if (!this->parentSensor)
+    gzthrow("UnderwaterSonarPlugin requires a Ray Sensor as its parent");
+
+  this->world = physics::get_world(this->parentSensor->WorldName());
+
+  this->newLaserScansConnection =
+    this->parentSensor->LaserShape()->ConnectNewLaserScans(
+      std::bind(&UnderwaterSonarPlugin::OnNewLaserScans, this));
+}
+
+/////////////////////////////////////////////////
+void UnderwaterSonarPlugin::OnNewLaserScans()
+{
+  /* overload with useful callback here */
+}

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
@@ -39,6 +39,7 @@
 #include <gazebo/sensors/SensorFactory.hh>
 #include <smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh>
 #include <smarc_gazebo_plugins/UnderwaterSonarSensor.hh>
+#include <smarc_gazebo_plugins/SemanticMultiRayShape.hh>
 #include <gazebo/sensors/Noise.hh>
 
 using namespace gazebo;
@@ -556,6 +557,11 @@ bool UnderwaterSonarSensor::UpdateImpl(const bool /*_force*/)
         range = this->dataPtr->laserShape->GetRange(j * this->RayCount() + i);
         intensity = this->dataPtr->laserShape->GetRetro(j *
             this->RayCount() + i);
+        physics::RayShapePtr ray = physics::SemanticMultiRayShape::StaticGetRay(this->dataPtr->laserShape, j * this->RayCount() + i);
+        double _dist;
+        std::string _entity;
+        ray->GetIntersection(_dist, _entity);
+        printf("%s", _entity.c_str());
       }
 
       // Mask ranges outside of min/max to +/- inf, as per REP 117

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
@@ -44,7 +44,7 @@
 using namespace gazebo;
 using namespace sensors;
 
-GZ_REGISTER_STATIC_SENSOR("ray", UnderwaterSonarSensor)
+GZ_REGISTER_STATIC_SENSOR("underwater_sonar", UnderwaterSonarSensor)
 
 //////////////////////////////////////////////////
 UnderwaterSonarSensor::UnderwaterSonarSensor()

--- a/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
+++ b/smarc_gazebo_plugins/smarc_gazebo_plugins/src/UnderwaterSonarSensor.cc
@@ -1,0 +1,607 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+  #include <Winsock2.h>
+#endif
+
+#include <boost/algorithm/string.hpp>
+
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/MultiRayShape.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
+#include <gazebo/physics/PhysicsIface.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/Collision.hh>
+
+#include <gazebo/common/Assert.hh>
+#include <gazebo/common/Exception.hh>
+
+#include <gazebo/transport/Node.hh>
+#include <gazebo/transport/Publisher.hh>
+#include <gazebo/msgs/msgs.hh>
+
+#include <gazebo/sensors/SensorFactory.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarSensorPrivate.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarSensor.hh>
+#include <gazebo/sensors/Noise.hh>
+
+using namespace gazebo;
+using namespace sensors;
+
+GZ_REGISTER_STATIC_SENSOR("ray", UnderwaterSonarSensor)
+
+//////////////////////////////////////////////////
+UnderwaterSonarSensor::UnderwaterSonarSensor()
+: Sensor(sensors::RAY),
+  dataPtr(new UnderwaterSonarSensorPrivate)
+{
+}
+
+//////////////////////////////////////////////////
+UnderwaterSonarSensor::~UnderwaterSonarSensor()
+{
+}
+
+//////////////////////////////////////////////////
+std::string UnderwaterSonarSensor::Topic() const
+{
+  std::string topicName = "~/";
+  topicName += this->ParentName() + "/" + this->Name() + "/scan";
+  boost::replace_all(topicName, "::", "/");
+
+  return topicName;
+}
+
+//////////////////////////////////////////////////
+void UnderwaterSonarSensor::Load(const std::string &_worldName)
+{
+  Sensor::Load(_worldName);
+  this->dataPtr->scanPub =
+    this->node->Advertise<msgs::LaserScanStamped>(this->Topic(), 50);
+
+  GZ_ASSERT(this->world != NULL,
+      "UnderwaterSonarSensor did not get a valid World pointer");
+
+  physics::PhysicsEnginePtr physicsEngine =
+    this->world->GetPhysicsEngine();
+
+  GZ_ASSERT(physicsEngine != NULL,
+      "Unable to get a pointer to the physics engine");
+
+  this->dataPtr->laserCollision = physicsEngine->CreateCollision("multiray",
+      this->ParentName());
+
+  GZ_ASSERT(this->dataPtr->laserCollision != NULL,
+      "Unable to create a multiray collision using the physics engine.");
+
+  this->dataPtr->laserCollision->SetName("ray_sensor_collision");
+  this->dataPtr->laserCollision->SetRelativePose(this->pose);
+  this->dataPtr->laserCollision->SetInitialRelativePose(this->pose);
+
+  this->dataPtr->laserShape =
+    boost::dynamic_pointer_cast<physics::MultiRayShape>(
+        this->dataPtr->laserCollision->GetShape());
+
+  GZ_ASSERT(this->dataPtr->laserShape != NULL,
+      "Unable to get the laser shape from the multi-ray collision.");
+
+  this->dataPtr->laserShape->Load(this->sdf);
+  this->dataPtr->laserShape->Init();
+
+  // Handle noise model settings.
+  sdf::ElementPtr rayElem = this->sdf->GetElement("ray");
+  if (rayElem->HasElement("noise"))
+  {
+    this->noises[RAY_NOISE] =
+        NoiseFactory::NewNoiseModel(rayElem->GetElement("noise"),
+        this->Type());
+  }
+
+  this->dataPtr->parentEntity =
+    this->world->GetEntity(this->ParentName());
+
+  GZ_ASSERT(this->dataPtr->parentEntity != NULL,
+      "Unable to get the parent entity.");
+}
+
+//////////////////////////////////////////////////
+void UnderwaterSonarSensor::Init()
+{
+  Sensor::Init();
+  this->dataPtr->laserMsg.mutable_scan()->set_frame(this->ParentName());
+}
+
+//////////////////////////////////////////////////
+void UnderwaterSonarSensor::Fini()
+{
+  Sensor::Fini();
+
+  this->dataPtr->scanPub.reset();
+
+  if (this->dataPtr->laserCollision)
+  {
+    this->dataPtr->laserCollision->Fini();
+    this->dataPtr->laserCollision.reset();
+  }
+
+  if (this->dataPtr->laserShape)
+  {
+    this->dataPtr->laserShape->Fini();
+    this->dataPtr->laserShape.reset();
+  }
+}
+
+//////////////////////////////////////////////////
+ignition::math::Angle UnderwaterSonarSensor::AngleMin() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetMinAngle().Ign();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+ignition::math::Angle UnderwaterSonarSensor::AngleMax() const
+{
+  if (this->dataPtr->laserShape)
+  {
+    return ignition::math::Angle(
+        this->dataPtr->laserShape->GetMaxAngle().Radian());
+  }
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetRangeMin() const
+{
+  return this->RangeMin();
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::RangeMin() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetMinRange();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetRangeMax() const
+{
+  return this->RangeMax();
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::RangeMax() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetMaxRange();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetAngleResolution() const
+{
+  return this->AngleResolution();
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::AngleResolution() const
+{
+  return (this->AngleMax() - this->AngleMin()).Radian() /
+    (this->RangeCount()-1);
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetRangeResolution() const
+{
+  return this->RangeResolution();
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::RangeResolution() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetResRange();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::GetRayCount() const
+{
+  return this->RayCount();
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::RayCount() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetSampleCount();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::GetRangeCount() const
+{
+  return this->RangeCount();
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::RangeCount() const
+{
+  // TODO: maybe should check against this->dataPtr->laserMsg.ranges_size()
+  //       as users use this to loop through GetRange() calls
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetSampleCount() *
+      this->dataPtr->laserShape->GetScanResolution();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::GetVerticalRayCount() const
+{
+  return this->VerticalRayCount();
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::VerticalRayCount() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetVerticalSampleCount();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::GetVerticalRangeCount() const
+{
+  return this->VerticalRangeCount();
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::VerticalRangeCount() const
+{
+  if (this->dataPtr->laserShape)
+    return this->dataPtr->laserShape->GetVerticalSampleCount() *
+      this->dataPtr->laserShape->GetVerticalScanResolution();
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+ignition::math::Angle UnderwaterSonarSensor::VerticalAngleMin() const
+{
+  if (this->dataPtr->laserShape)
+  {
+    return ignition::math::Angle(
+        this->dataPtr->laserShape->GetVerticalMinAngle().Radian());
+  }
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+ignition::math::Angle UnderwaterSonarSensor::VerticalAngleMax() const
+{
+  if (this->dataPtr->laserShape)
+  {
+    return ignition::math::Angle(
+        this->dataPtr->laserShape->GetVerticalMaxAngle().Radian());
+  }
+  else
+    return -1;
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetVerticalAngleResolution() const
+{
+  return this->VerticalAngleResolution();
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::VerticalAngleResolution() const
+{
+  return (this->VerticalAngleMax() - this->VerticalAngleMin()).Radian() /
+    (this->VerticalRangeCount()-1);
+}
+
+//////////////////////////////////////////////////
+void UnderwaterSonarSensor::GetRanges(std::vector<double> &_ranges)
+{
+  this->Ranges(_ranges);
+}
+
+//////////////////////////////////////////////////
+void UnderwaterSonarSensor::Ranges(std::vector<double> &_ranges) const
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  _ranges.resize(this->dataPtr->laserMsg.scan().ranges_size());
+  memcpy(&_ranges[0], this->dataPtr->laserMsg.scan().ranges().data(),
+         sizeof(_ranges[0]) * this->dataPtr->laserMsg.scan().ranges_size());
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetRange(unsigned int _index)
+{
+  return this->Range(_index);
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::Range(const unsigned int _index) const
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  if (this->dataPtr->laserMsg.scan().ranges_size() == 0)
+  {
+    gzwarn << "ranges not constructed yet (zero sized)\n";
+    return 0.0;
+  }
+  if (static_cast<int>(_index) >= this->dataPtr->laserMsg.scan().ranges_size())
+  {
+    gzerr << "Invalid range index[" << _index << "]\n";
+    return 0.0;
+  }
+
+  return this->dataPtr->laserMsg.scan().ranges(_index);
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::GetRetro(unsigned int _index)
+{
+  return this->Retro(_index);
+}
+
+//////////////////////////////////////////////////
+double UnderwaterSonarSensor::Retro(const unsigned int _index) const
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  if (this->dataPtr->laserMsg.scan().intensities_size() == 0)
+  {
+    gzwarn << "Intensities not constructed yet (zero size)\n";
+    return 0.0;
+  }
+  if (static_cast<int>(_index) >=
+      this->dataPtr->laserMsg.scan().intensities_size())
+  {
+    gzerr << "Invalid intensity index[" << _index << "]\n";
+    return 0.0;
+  }
+
+  return this->dataPtr->laserMsg.scan().intensities(_index);
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::GetFiducial(unsigned int _index)
+{
+  return this->Fiducial(_index);
+}
+
+//////////////////////////////////////////////////
+int UnderwaterSonarSensor::Fiducial(const unsigned int _index) const
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  // Convert range index to ray index.
+  // Find vertical/horizontal range indices (vIdx, hIdx) and mulitply
+  // by the ratio of ray count to range count to get the vertical/horizontal
+  // ray indices, which are then used to compute the final index into ray array.
+  int vIdx = _index / this->RangeCount();
+  vIdx = vIdx * this->VerticalRayCount() / this->VerticalRangeCount();
+  int hIdx = _index % this->RangeCount();
+  hIdx = hIdx * this->RayCount() / this->RangeCount();
+  int idx = vIdx * this->RayCount()  + hIdx;
+
+  if (idx >= this->RayCount() * this->VerticalRayCount())
+  {
+    gzerr << "Invalid fiducial index[" << _index << "]\n";
+    return 0.0;
+  }
+  return this->dataPtr->laserShape->GetFiducial(idx);
+}
+
+//////////////////////////////////////////////////
+bool UnderwaterSonarSensor::UpdateImpl(const bool /*_force*/)
+{
+  // do the collision checks
+  // this eventually call OnNewScans, so move mutex lock behind it in case
+  // need to move mutex lock after this? or make the OnNewLaserScan connection
+  // call somewhere else?
+  this->dataPtr->laserShape->Update();
+  this->lastMeasurementTime = this->world->GetSimTime();
+
+  // moving this behind laserShape update
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  msgs::Set(this->dataPtr->laserMsg.mutable_time(),
+            this->lastMeasurementTime);
+
+  msgs::LaserScan *scan = this->dataPtr->laserMsg.mutable_scan();
+
+  // Store the latest laser scans into laserMsg
+  msgs::Set(scan->mutable_world_pose(),
+      this->pose + this->dataPtr->parentEntity->GetWorldPose().Ign());
+  scan->set_angle_min(this->AngleMin().Radian());
+  scan->set_angle_max(this->AngleMax().Radian());
+  scan->set_angle_step(this->AngleResolution());
+  scan->set_count(this->RangeCount());
+
+  scan->set_vertical_angle_min(this->VerticalAngleMin().Radian());
+  scan->set_vertical_angle_max(this->VerticalAngleMax().Radian());
+  scan->set_vertical_angle_step(this->VerticalAngleResolution());
+  scan->set_vertical_count(this->VerticalRangeCount());
+
+  scan->set_range_min(this->RangeMin());
+  scan->set_range_max(this->RangeMax());
+
+  scan->clear_ranges();
+  scan->clear_intensities();
+
+  unsigned int rayCount = this->RayCount();
+  unsigned int rangeCount = this->RangeCount();
+  unsigned int verticalRayCount = this->VerticalRayCount();
+  unsigned int verticalRangeCount = this->VerticalRangeCount();
+
+  // Interpolation: for every point in range count, compute interpolated value
+  // using four bounding ray samples.
+  // (vja, hja)   (vja, hjb)
+  //       x---------x
+  //       |         |
+  //       |    o    |
+  //       |         |
+  //       x---------x
+  // (vjb, hja)   (vjb, hjb)
+  // where o: is the range to be interpolated
+  //       x: ray sample
+  //       vja: is the previous index of ray in vertical direction
+  //       vjb: is the next index of ray in vertical direction
+  //       hja: is the previous index of ray in horizontal direction
+  //       hjb: is the next index of ray in horizontal direction
+  unsigned int hja, hjb;
+  unsigned int vja = 0, vjb = 0;
+  // percentage of interpolation between rays
+  double vb = 0, hb;
+  // indices of ray samples
+  int j1, j2, j3, j4;
+  // range values of ray samples
+  double r1, r2, r3, r4;
+
+  // Check for the common case of vertical and horizontal resolution being 1,
+  // which means that ray count == range count and we can do simple lookup
+  // of ranges and intensity data, skipping interpolation.  We could do this
+  // check independently for vertical and horizontal, but that's more
+  // complexity for an unlikely use case.
+  bool interp =
+    ((rayCount != rangeCount) || (verticalRayCount != verticalRangeCount));
+
+  // interpolate in vertical direction
+  for (unsigned int j = 0; j < verticalRangeCount; ++j)
+  {
+    if (interp)
+    {
+      vb = (verticalRangeCount == 1) ? 0 :
+          static_cast<double>(j * (verticalRayCount - 1))
+          / (verticalRangeCount - 1);
+      vja = static_cast<int>(floor(vb));
+      vjb = std::min(vja + 1, verticalRayCount - 1);
+      vb = vb - floor(vb);
+
+      GZ_ASSERT(vja < verticalRayCount,
+          "Invalid vertical ray index used for interpolation");
+      GZ_ASSERT(vjb < verticalRayCount,
+          "Invalid vertical ray index used for interpolation");
+    }
+    // interpolate in horizontal direction
+    for (unsigned int i = 0; i < rangeCount; ++i)
+    {
+      double range, intensity;
+      if (interp)
+      {
+        hb = (rangeCount == 1)? 0 : static_cast<double>(i * (rayCount - 1))
+            / (rangeCount - 1);
+        hja = static_cast<int>(floor(hb));
+        hjb = std::min(hja + 1, rayCount - 1);
+        hb = hb - floor(hb);
+
+        GZ_ASSERT(hja < rayCount,
+            "Invalid horizontal ray index used for interpolation");
+        GZ_ASSERT(hjb < rayCount,
+            "Invalid horizontal ray index used for interpolation");
+
+        // indices of 4 corners
+        j1 = hja + vja * rayCount;
+        j2 = hjb + vja * rayCount;
+        j3 = hja + vjb * rayCount;
+        j4 = hjb + vjb * rayCount;
+
+        // range readings of 4 corners
+        r1 = this->LaserShape()->GetRange(j1);
+        r2 = this->LaserShape()->GetRange(j2);
+        r3 = this->LaserShape()->GetRange(j3);
+        r4 = this->LaserShape()->GetRange(j4);
+        range = (1-vb)*((1 - hb) * r1 + hb * r2)
+            + vb *((1 - hb) * r3 + hb * r4);
+
+        // intensity is averaged
+        intensity = 0.25 * (this->LaserShape()->GetRetro(j1)
+            + this->LaserShape()->GetRetro(j2)
+            + this->LaserShape()->GetRetro(j3)
+            + this->LaserShape()->GetRetro(j4));
+      }
+      else
+      {
+        range = this->dataPtr->laserShape->GetRange(j * this->RayCount() + i);
+        intensity = this->dataPtr->laserShape->GetRetro(j *
+            this->RayCount() + i);
+      }
+
+      // Mask ranges outside of min/max to +/- inf, as per REP 117
+      if (range >= this->RangeMax())
+      {
+        range = IGN_DBL_INF;
+      }
+      else if (range <= this->RangeMin())
+      {
+        range = -IGN_DBL_INF;
+      }
+      else if (this->noises.find(RAY_NOISE) !=
+               this->noises.end())
+      {
+        // currently supports only one noise model per laser sensor
+        range = this->noises[RAY_NOISE]->Apply(range);
+        range = ignition::math::clamp(range,
+            this->RangeMin(), this->RangeMax());
+      }
+
+      scan->add_ranges(range);
+      scan->add_intensities(intensity);
+    }
+  }
+
+  if (this->dataPtr->scanPub && this->dataPtr->scanPub->HasConnections())
+    this->dataPtr->scanPub->Publish(this->dataPtr->laserMsg);
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool UnderwaterSonarSensor::IsActive() const
+{
+  return Sensor::IsActive() ||
+    (this->dataPtr->scanPub && this->dataPtr->scanPub->HasConnections());
+}
+
+//////////////////////////////////////////////////
+physics::MultiRayShapePtr UnderwaterSonarSensor::GetLaserShape() const
+{
+  return this->LaserShape();
+}
+
+//////////////////////////////////////////////////
+physics::MultiRayShapePtr UnderwaterSonarSensor::LaserShape() const
+{
+  return this->dataPtr->laserShape;
+}

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  message_generation
   smarc_gazebo_plugins
   sensor_msgs
   geometry_msgs
@@ -49,11 +50,10 @@ find_package(gazebo REQUIRED)
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  SonarEntities.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -70,10 +70,10 @@ find_package(gazebo REQUIRED)
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs  # Or other packages containing msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -142,7 +142,7 @@ add_library(underwater_sonar_ros_plugin src/gazebo_ros_underwater_sonar.cpp)
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(underwater_sonar_ros_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/CMakeLists.txt
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/CMakeLists.txt
@@ -1,0 +1,213 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(smarc_gazebo_ros_plugins)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  smarc_gazebo_plugins
+  sensor_msgs
+  geometry_msgs
+  std_msgs
+  roscpp
+  visualization_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+find_package(gazebo REQUIRED)
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+ INCLUDE_DIRS include
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+  ${GAZEBO_MSG_INCLUDE_DIRS}
+ LIBRARIES underwater_sonar_ros_plugin
+ CATKIN_DEPENDS smarc_gazebo_plugins
+  sensor_msgs
+  geometry_msgs
+  std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+  ${GAZEBO_MSG_INCLUDE_DIRS}
+)
+
+link_directories(
+  ${GAZEBO_LIBRARY_DIRS}
+)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
+
+## Declare a C++ library
+add_library(underwater_sonar_ros_plugin src/gazebo_ros_underwater_sonar.cpp)
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/smarc_gazebo_ros_plugins_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(underwater_sonar_ros_plugin
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS underwater_sonar_ros_plugin
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_smarc_gazebo_ros_plugins.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GAZEBO_UNDERWATER_SONAR_HH
+#define GAZEBO_UNDERWATER_SONAR_HH
+
+#include <string>
+
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+
+#include <ros/ros.h>
+#include <ros/advertise_options.h>
+#include <sensor_msgs/LaserScan.h>
+
+#include <sdf/Param.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/msgs/MessageTypes.hh>
+#include <gazebo/common/Time.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+#include <smarc_gazebo_plugins/UnderwaterSonarPlugin.hh>
+#include <gazebo_plugins/gazebo_ros_utils.h>
+
+#include <gazebo_plugins/PubQueue.h>
+
+namespace gazebo
+{
+  class GazeboUnderwaterSonar : public UnderwaterSonarPlugin
+  {
+    /// \brief Constructor
+    public: GazeboUnderwaterSonar();
+
+    /// \brief Destructor
+    public: ~GazeboUnderwaterSonar();
+
+    /// \brief Load the plugin
+    /// \param take in SDF root element
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Keep track of number of connctions
+    private: int laser_connect_count_;
+    private: void LaserConnect();
+    private: void LaserDisconnect();
+
+    // Pointer to the model
+    GazeboRosPtr gazebo_ros_;
+    private: std::string world_name_;
+    private: physics::WorldPtr world_;
+    /// \brief The parent sensor
+	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parent_ray_sensor_;
+
+    /// \brief pointer to ros node
+    private: ros::NodeHandle* rosnode_;
+    private: ros::Publisher pub_;
+    private: PubQueue<sensor_msgs::LaserScan>::Ptr pub_queue_;
+
+    /// \brief topic name
+    private: std::string topic_name_;
+
+    /// \brief frame transform name, should match link name
+    private: std::string frame_name_;
+
+    /// \brief tf prefix
+    private: std::string tf_prefix_;
+
+    /// \brief for setting ROS name space
+    private: std::string robot_namespace_;
+
+    // deferred load in case ros is blocking
+    private: sdf::ElementPtr sdf;
+    private: void LoadThread();
+    private: boost::thread deferred_load_thread_;
+    private: unsigned int seed;
+
+    private: gazebo::transport::NodePtr gazebo_node_;
+    private: gazebo::transport::SubscriberPtr laser_scan_sub_;
+    private: void OnScan(ConstLaserScanStampedPtr &_msg);
+
+    /// \brief prevents blocking
+    private: PubMultiQueue pmq;
+  };
+}
+#endif // GAZEBO_UNDERWATER_SONAR_HH

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
@@ -36,6 +36,7 @@
 #include <gazebo/common/Events.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 #include <smarc_gazebo_plugins/UnderwaterSonarPlugin.hh>
+#include <gazebo/plugins/RayPlugin.hh>
 #include <gazebo_plugins/gazebo_ros_utils.h>
 
 #include <gazebo_plugins/PubQueue.h>
@@ -64,7 +65,7 @@ namespace gazebo
     private: std::string world_name_;
     private: physics::WorldPtr world_;
     /// \brief The parent sensor
-	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parent_ray_sensor_;
+	private: std::shared_ptr<sensors::RaySensor> parent_ray_sensor_;
 
     /// \brief pointer to ros node
     private: ros::NodeHandle* rosnode_;

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
@@ -40,6 +40,7 @@
 #include <gazebo_plugins/gazebo_ros_utils.h>
 
 #include <gazebo_plugins/PubQueue.h>
+#include <smarc_gazebo_ros_plugins/SonarEntities.h>
 
 namespace gazebo
 {
@@ -57,8 +58,11 @@ namespace gazebo
 
     /// \brief Keep track of number of connctions
     private: int laser_connect_count_;
+    private: int entities_connect_count_;
     private: void LaserConnect();
     private: void LaserDisconnect();
+    private: void EntitiesConnect();
+    private: void EntitiesDisconnect();
 
     // Pointer to the model
     GazeboRosPtr gazebo_ros_;
@@ -70,7 +74,9 @@ namespace gazebo
     /// \brief pointer to ros node
     private: ros::NodeHandle* rosnode_;
     private: ros::Publisher pub_;
+    private: ros::Publisher entities_pub_;
     private: PubQueue<sensor_msgs::LaserScan>::Ptr pub_queue_;
+    private: PubQueue<smarc_gazebo_ros_plugins::SonarEntities>::Ptr entities_pub_queue_;
 
     /// \brief topic name
     private: std::string topic_name_;
@@ -92,7 +98,9 @@ namespace gazebo
 
     private: gazebo::transport::NodePtr gazebo_node_;
     private: gazebo::transport::SubscriberPtr laser_scan_sub_;
+    private: gazebo::transport::SubscriberPtr entities_sub_;
     private: void OnScan(ConstLaserScanStampedPtr &_msg);
+    private: void OnEntities(ConstGzString_VPtr &_msg);
 
     /// \brief prevents blocking
     private: PubMultiQueue pmq;

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/include/smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h
@@ -65,7 +65,7 @@ namespace gazebo
     private: std::string world_name_;
     private: physics::WorldPtr world_;
     /// \brief The parent sensor
-	private: std::shared_ptr<sensors::RaySensor> parent_ray_sensor_;
+	private: std::shared_ptr<sensors::UnderwaterSonarSensor> parent_ray_sensor_;
 
     /// \brief pointer to ros node
     private: ros::NodeHandle* rosnode_;

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/msg/SonarEntities.msg
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/msg/SonarEntities.msg
@@ -1,0 +1,1 @@
+string[] entities

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/package.xml
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/package.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>smarc_gazebo_ros_plugins</name>
+  <version>0.0.0</version>
+  <description>The smarc_gazebo_ros_plugins package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/smarc_gazebo_ros_plugins</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>smarc_gazebo_plugins</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+  <exec_depend>smarc_gazebo_plugins</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
@@ -74,7 +74,7 @@ void GazeboUnderwaterSonar::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sd
 
   GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST;
   this->parent_ray_sensor_ =
-    dynamic_pointer_cast<sensors::RaySensor>(_parent);
+    dynamic_pointer_cast<sensors::UnderwaterSonarSensor>(_parent);
 
   if (!this->parent_ray_sensor_)
     gzthrow("GazeboUnderwaterSonar controller requires a Ray Sensor as its parent");

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
@@ -74,7 +74,7 @@ void GazeboUnderwaterSonar::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sd
 
   GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST;
   this->parent_ray_sensor_ =
-    dynamic_pointer_cast<sensors::UnderwaterSonarSensor>(_parent);
+    dynamic_pointer_cast<sensors::RaySensor>(_parent);
 
   if (!this->parent_ray_sensor_)
     gzthrow("GazeboUnderwaterSonar controller requires a Ray Sensor as its parent");

--- a/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
+++ b/smarc_gazebo_plugins/smarc_gazebo_ros_plugins/src/gazebo_ros_underwater_sonar.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+ * Desc: Ros Laser controller.
+ * Author: Nathan Koenig
+ * Date: 01 Feb 2007
+ */
+
+#include <algorithm>
+#include <string>
+#include <assert.h>
+
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/HingeJoint.hh>
+#include <gazebo/sensors/Sensor.hh>
+#include <sdf/sdf.hh>
+#include <sdf/Param.hh>
+#include <gazebo/common/Exception.hh>
+#include <gazebo/sensors/RaySensor.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/transport/transport.hh>
+
+#include <tf/tf.h>
+#include <tf/transform_listener.h>
+
+#include <smarc_gazebo_ros_plugins/gazebo_ros_underwater_sonar.h>
+
+namespace gazebo
+{
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(GazeboUnderwaterSonar)
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboUnderwaterSonar::GazeboUnderwaterSonar()
+{
+  this->seed = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboUnderwaterSonar::~GazeboUnderwaterSonar()
+{
+  this->rosnode_->shutdown();
+  delete this->rosnode_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboUnderwaterSonar::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
+{
+  // load plugin
+  UnderwaterSonarPlugin::Load(_parent, this->sdf);
+  // Get the world name.
+  std::string worldName = _parent->WorldName();
+  this->world_ = physics::get_world(worldName);
+  // save pointers
+  this->sdf = _sdf;
+
+  GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST;
+  this->parent_ray_sensor_ =
+    dynamic_pointer_cast<sensors::UnderwaterSonarSensor>(_parent);
+
+  if (!this->parent_ray_sensor_)
+    gzthrow("GazeboUnderwaterSonar controller requires a Ray Sensor as its parent");
+
+  this->robot_namespace_ =  GetRobotNamespace(_parent, _sdf, "Laser");
+
+  if (!this->sdf->HasElement("frameName"))
+  {
+    ROS_INFO_NAMED("laser", "Laser plugin missing <frameName>, defaults to /world");
+    this->frame_name_ = "/world";
+  }
+  else
+    this->frame_name_ = this->sdf->Get<std::string>("frameName");
+
+
+  if (!this->sdf->HasElement("topicName"))
+  {
+    ROS_INFO_NAMED("laser", "Laser plugin missing <topicName>, defaults to /world");
+    this->topic_name_ = "/world";
+  }
+  else
+    this->topic_name_ = this->sdf->Get<std::string>("topicName");
+
+  this->laser_connect_count_ = 0;
+
+    // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM_NAMED("laser", "A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  ROS_INFO_NAMED("laser", "Starting Laser Plugin (ns = %s)", this->robot_namespace_.c_str() );
+  // ros callback queue for processing subscription
+  this->deferred_load_thread_ = boost::thread(
+    boost::bind(&GazeboUnderwaterSonar::LoadThread, this));
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboUnderwaterSonar::LoadThread()
+{
+  this->gazebo_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
+  this->gazebo_node_->Init(this->world_name_);
+
+  this->pmq.startServiceThread();
+
+  this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
+
+  this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
+  if(this->tf_prefix_.empty()) {
+      this->tf_prefix_ = this->robot_namespace_;
+      boost::trim_right_if(this->tf_prefix_,boost::is_any_of("/"));
+  }
+  ROS_INFO_NAMED("laser", "Laser Plugin (ns = %s)  <tf_prefix_>, set to \"%s\"",
+             this->robot_namespace_.c_str(), this->tf_prefix_.c_str());
+
+  // resolve tf prefix
+  this->frame_name_ = tf::resolve(this->tf_prefix_, this->frame_name_);
+
+  if (this->topic_name_ != "")
+  {
+    ros::AdvertiseOptions ao =
+      ros::AdvertiseOptions::create<sensor_msgs::LaserScan>(
+      this->topic_name_, 1,
+      boost::bind(&GazeboUnderwaterSonar::LaserConnect, this),
+      boost::bind(&GazeboUnderwaterSonar::LaserDisconnect, this),
+      ros::VoidPtr(), NULL);
+    this->pub_ = this->rosnode_->advertise(ao);
+    this->pub_queue_ = this->pmq.addPub<sensor_msgs::LaserScan>();
+  }
+
+  // Initialize the controller
+
+  // sensor generation off by default
+  this->parent_ray_sensor_->SetActive(false);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Increment count
+void GazeboUnderwaterSonar::LaserConnect()
+{
+  this->laser_connect_count_++;
+  if (this->laser_connect_count_ == 1)
+    this->laser_scan_sub_ =
+      this->gazebo_node_->Subscribe(this->parent_ray_sensor_->Topic(),
+                                    &GazeboUnderwaterSonar::OnScan, this);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Decrement count
+void GazeboUnderwaterSonar::LaserDisconnect()
+{
+  this->laser_connect_count_--;
+  if (this->laser_connect_count_ == 0)
+    this->laser_scan_sub_.reset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Convert new Gazebo message to ROS message and publish it
+void GazeboUnderwaterSonar::OnScan(ConstLaserScanStampedPtr &_msg)
+{
+  // We got a new message from the Gazebo sensor.  Stuff a
+  // corresponding ROS message and publish it.
+  sensor_msgs::LaserScan laser_msg;
+  laser_msg.header.stamp = ros::Time(_msg->time().sec(), _msg->time().nsec());
+  laser_msg.header.frame_id = this->frame_name_;
+  laser_msg.angle_min = _msg->scan().angle_min();
+  laser_msg.angle_max = _msg->scan().angle_max();
+  laser_msg.angle_increment = _msg->scan().angle_step();
+  laser_msg.time_increment = 0;  // instantaneous simulator scan
+  laser_msg.scan_time = 0;  // not sure whether this is correct
+  laser_msg.range_min = _msg->scan().range_min();
+  laser_msg.range_max = _msg->scan().range_max();
+  laser_msg.ranges.resize(_msg->scan().ranges_size());
+  std::copy(_msg->scan().ranges().begin(),
+            _msg->scan().ranges().end(),
+            laser_msg.ranges.begin());
+  laser_msg.intensities.resize(_msg->scan().intensities_size());
+  std::copy(_msg->scan().intensities().begin(),
+            _msg->scan().intensities().end(),
+            laser_msg.intensities.begin());
+  this->pub_queue_->push(laser_msg, this->pub_);
+}
+}

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/CMakeLists.txt
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(smarc_sensor_plugins_ros)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS sensor_msgs smarc_gazebo_ros_plugins cv_bridge)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -113,7 +113,7 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(
 # include
-# ${catkin_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -129,7 +129,7 @@ include_directories(
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/smarc_sensor_plugins_ros_node.cpp)
+add_executable(sidescan_waterfall_image_node src/sidescan_waterfall_image_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -142,9 +142,9 @@ include_directories(
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
+target_link_libraries(sidescan_waterfall_image_node
+  ${catkin_LIBRARIES}
+)
 
 #############
 ## Install ##

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/CMakeLists.txt
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/CMakeLists.txt
@@ -7,7 +7,7 @@ add_compile_options(-std=c++11)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS sensor_msgs smarc_gazebo_ros_plugins cv_bridge)
+find_package(catkin REQUIRED COMPONENTS sensor_msgs smarc_gazebo_ros_plugins cv_bridge message_filters)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -130,6 +130,7 @@ include_directories(
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 add_executable(sidescan_waterfall_image_node src/sidescan_waterfall_image_node.cpp)
+add_executable(combine_waterfalls_node src/combine_waterfalls_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -143,6 +144,10 @@ add_executable(sidescan_waterfall_image_node src/sidescan_waterfall_image_node.c
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(sidescan_waterfall_image_node
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(combine_waterfalls_node
   ${catkin_LIBRARIES}
 )
 

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/launch/waterfall.launch
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/launch/waterfall.launch
@@ -1,0 +1,19 @@
+<launch>
+
+  <arg name="namespace" default="small_smarc_auv"/>
+
+  <node name="left_sidescan_waterfall_image_node" pkg="smarc_sensor_plugins_ros" type="sidescan_waterfall_image_node" output="screen">
+    <param name="auv_name" value="$(arg namespace)" />
+    <param name="is_left" value="true" />
+  </node>
+
+  <node name="right_sidescan_waterfall_image_node" pkg="smarc_sensor_plugins_ros" type="sidescan_waterfall_image_node" output="screen">
+    <param name="auv_name" value="$(arg namespace)" />
+    <param name="is_left" value="false" />
+  </node>
+
+  <node name="combine_waterfalls_node" pkg="smarc_sensor_plugins_ros" type="combine_waterfalls_node" output="screen">
+    <param name="auv_name" value="$(arg namespace)" />
+  </node>
+
+</launch>

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/package.xml
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/package.xml
@@ -40,7 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-
+  <build_depend>smarc_gazebo_ros_plugins</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <run_depend>smarc_gazebo_ros_plugins</run_depend>
+  <run_depend>cv_bridge</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/src/combine_waterfalls_node.cpp
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/src/combine_waterfalls_node.cpp
@@ -1,0 +1,93 @@
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/Image.h>
+#include <smarc_gazebo_ros_plugins/SonarEntities.h>
+
+#include <opencv2/core.hpp>
+#include <sensor_msgs/image_encodings.h>
+#include <cv_bridge/cv_bridge.h>
+#include <Eigen/Dense>
+#include <cmath>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+using namespace std;
+
+class CombineWaterfallImageNode {
+
+public:
+
+    typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> MySyncPolicy;
+
+    ros::NodeHandle n;
+    ros::Publisher waterfall_pub;
+    message_filters::Subscriber<sensor_msgs::Image>* waterfall_left_sub;
+    message_filters::Subscriber<sensor_msgs::Image>* waterfall_right_sub;
+    message_filters::Synchronizer<MySyncPolicy>* sync;
+
+    string auv_namespace;
+
+    CombineWaterfallImageNode()
+    {
+        ros::NodeHandle pn("~");
+        string auv_name;
+        pn.param<string>("auv_name", auv_name, "small_smarc_auv");
+        auv_namespace = string("/") + auv_name;
+
+        waterfall_left_sub = new message_filters::Subscriber<sensor_msgs::Image>(n, auv_namespace+"/sss_left_waterfall", 1);
+        waterfall_right_sub = new message_filters::Subscriber<sensor_msgs::Image>(n, auv_namespace+"/sss_right_waterfall", 1);
+
+        // ApproximateTime takes a queue size as its constructor argument, hence MySyncPolicy(10)
+        sync = new message_filters::Synchronizer<MySyncPolicy>(MySyncPolicy(10), *waterfall_left_sub, *waterfall_right_sub);
+        sync->registerCallback(boost::bind(&CombineWaterfallImageNode::callback, this, _1, _2));
+
+        waterfall_pub = n.advertise<sensor_msgs::Image>(auv_namespace+"/waterfall", 1);
+    }
+
+    void callback(const sensor_msgs::Image::ConstPtr& image_left, const sensor_msgs::Image::ConstPtr& image_right)
+    {
+        cv_bridge::CvImagePtr cv_left_ptr;
+        try {
+            cv_left_ptr = cv_bridge::toCvCopy(image_left, sensor_msgs::image_encodings::MONO8);
+        }
+        catch (cv_bridge::Exception& e) {
+            ROS_ERROR("cv_bridge exception: %s", e.what());
+            return;
+        }
+
+        cv_bridge::CvImagePtr cv_right_ptr;
+        try {
+            cv_right_ptr = cv_bridge::toCvCopy(image_right, sensor_msgs::image_encodings::MONO8);
+        }
+        catch (cv_bridge::Exception& e) {
+            ROS_ERROR("cv_bridge exception: %s", e.what());
+            return;
+        }
+
+        cv::Mat image = cv_left_ptr->image + cv_right_ptr->image;
+
+        sensor_msgs::Image img_msg; // >> message to be sent
+        std_msgs::Header header; // empty header
+        //header.seq = counter; // user defined counter
+        header.stamp = ros::Time::now(); // time
+        cv_bridge::CvImage img_bridge;
+        img_bridge = cv_bridge::CvImage(header, sensor_msgs::image_encodings::MONO8, image);
+        img_bridge.toImageMsg(img_msg); // from cv_bridge to sensor_msgs::Image
+        
+        waterfall_pub.publish(img_msg); // ros::Publisher pub_img = node.advertise<sensor_msgs::Image>("topic", queuesize);
+    }
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "combine_waterfalls_node");
+
+    CombineWaterfallImageNode node;
+
+    ros::spin();
+
+    return 0;
+}

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/src/sidescan_waterfall_image_node.cpp
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/src/sidescan_waterfall_image_node.cpp
@@ -1,0 +1,161 @@
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/Image.h>
+#include <smarc_gazebo_ros_plugins/SonarEntities.h>
+
+#include <opencv2/core.hpp>
+#include <sensor_msgs/image_encodings.h>
+#include <cv_bridge/cv_bridge.h>
+#include <Eigen/Dense>
+#include <cmath>
+
+using namespace std;
+
+class WaterfallImageNode {
+
+public:
+
+    ros::NodeHandle n;
+    ros::Subscriber sonar_left_sub;
+    ros::Subscriber sonar_right_sub;
+    ros::Subscriber entity_left_sub;
+    ros::Subscriber entity_right_sub;
+    ros::Publisher waterfall_pub;
+
+    string auv_namespace;
+    cv::Mat waterfall_image;
+    int timesteps;
+    double start_angle;
+    double fov;
+    int rays;
+    int samples;
+    int offset;
+    int width;
+    bool angle_unknown;
+
+    Eigen::VectorXi sample_indices;
+
+    WaterfallImageNode()
+    {
+        ros::NodeHandle pn("~");
+        string auv_name;
+        pn.param<string>("auv_name", auv_name, "small_smarc_auv");
+        auv_namespace = string("/") + auv_name;
+        pn.param<int>("timesteps", timesteps, 200);
+        pn.param<double>("start_angle", start_angle, 0.0);
+        pn.param<double>("fov", fov, 60.0);
+        fov *= M_PI/180.0;
+        pn.param<int>("rays", rays, 59);
+        pn.param<int>("samples", samples, 40);
+        pn.param<bool>("angle_unknown", angle_unknown, true);
+
+        // with start angle and fov, we should be able to decide the index of the samples to keep
+        sample_indices.resize(samples);
+        double height = double(samples)/tan(fov);
+        cout << "Height: " << height << endl;
+        for (int i = 0; i < samples; ++i) {
+            double dindex = atan(double(i+0.5)/height);
+            int index = int(dindex*double(rays)/fov);
+            sample_indices[i] = index;
+        }
+
+        cout << "Sample indices: " << sample_indices << endl;
+
+        offset = 10;
+        width = 2*samples+2*width;
+        waterfall_image = cv::Mat::zeros(timesteps, width, CV_8UC1);
+
+        waterfall_pub = n.advertise<sensor_msgs::Image>(auv_namespace+"/waterfall_image", 1);
+        sonar_left_sub = n.subscribe(auv_namespace+"/sss_left", 10, &WaterfallImageNode::sonar_left_callback, this);
+        sonar_right_sub = n.subscribe(auv_namespace+"/sss_right", 10, &WaterfallImageNode::sonar_right_callback, this);
+        entity_left_sub = n.subscribe(auv_namespace+"/sss_left_entities", 10, &WaterfallImageNode::entities_left_callback, this);
+        entity_right_sub = n.subscribe(auv_namespace+"/sss_right_entities", 10, &WaterfallImageNode::entities_right_callback, this);
+    }
+
+    void sonar_left_callback(const sensor_msgs::LaserScan::ConstPtr& scan)
+    {
+        auto max_intensity_iter = std::max_element(scan->intensities.begin(), scan->intensities.end());
+        auto max_range_iter = std::max_element(scan->ranges.begin(), scan->ranges.end());
+        double min_range = scan->ranges[0];
+        double max_range = *max_range_iter - min_range;
+
+        cout << "=========" << endl;
+        cout << max_range << endl;
+        cout << min_range << endl;
+        cout << *max_intensity_iter << endl;
+
+        size_t max_index = std::distance(scan->intensities.begin(), max_intensity_iter);
+
+        /*
+        int max_index = 0;
+        for (int i = 0; i < scan->intensities.size(); ++i) {
+            max_index = scan->intensities[i] > scan->intensities[max_index]? i : max_index; 
+        }
+        */
+
+        double scale = 1.0; //255.0/max_index;
+
+        // now we should move everything now one notch
+        // let's just do the left for now, maybe synch later
+        cv::Mat shifted = cv::Mat::zeros(timesteps, width, waterfall_image.type());
+        waterfall_image(cv::Rect(0, 0, waterfall_image.cols, waterfall_image.rows-1)).copyTo(shifted(cv::Rect(0, 1, shifted.cols, shifted.rows-1)));
+        shifted.copyTo(waterfall_image);
+
+		if (angle_unknown) {
+            int ray = 0;
+            for (int i = 0; i < samples && ray < rays; ) {
+                if ((scan->ranges[ray] - min_range) > max_range*double(i)/double(samples)) {
+                    ++i;
+                }
+                else {
+                    waterfall_image.at<uchar>(0, width/2-offset-1-i) = uchar(scale*scan->intensities[ray]);
+                    //++i;
+                    ++ray;
+                }
+            }
+		}
+		else {
+            for (int i = 0; i < samples; ++i) {
+                waterfall_image.at<uchar>(0, width/2-offset-1-i) = uchar(scale*scan->intensities[sample_indices(i)]);
+            }
+        }
+
+        sensor_msgs::Image img_msg; // >> message to be sent
+
+        std_msgs::Header header; // empty header
+        //header.seq = counter; // user defined counter
+        header.stamp = ros::Time::now(); // time
+        cv_bridge::CvImage img_bridge;
+        img_bridge = cv_bridge::CvImage(header, sensor_msgs::image_encodings::MONO8, waterfall_image);
+        img_bridge.toImageMsg(img_msg); // from cv_bridge to sensor_msgs::Image
+        
+        waterfall_pub.publish(img_msg); // ros::Publisher pub_img = node.advertise<sensor_msgs::Image>("topic", queuesize);
+    }
+    
+    void sonar_right_callback(const sensor_msgs::LaserScan::ConstPtr& scan)
+    {
+        // now we should move everything now one notch
+    }
+
+    void entities_left_callback(const smarc_gazebo_ros_plugins::SonarEntities::ConstPtr& msg)
+    {
+
+    }
+
+    void entities_right_callback(const smarc_gazebo_ros_plugins::SonarEntities::ConstPtr& msg)
+    {
+
+    }
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "sidescan_waterfall_image_node");
+
+    WaterfallImageNode node;
+
+    ros::spin();
+
+    return 0;
+}

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
@@ -66,6 +66,12 @@
             <min_angle>-${0.5*fov}</min_angle>
             <max_angle>${0.5*fov}</max_angle>
           </horizontal>
+		  <vertical>
+		    <resolution>0.5</resolution>
+		    <samples>2</samples>
+			<min_angle>-${0.5*fov/samples}</min_angle>
+            <max_angle>${0.5*fov/samples}</max_angle>
+		  </vertical>
         </scan>
         <range>
           <min>${range_min}</min>

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
@@ -49,7 +49,7 @@
     <limit upper="0" lower="0" effort="0" velocity="0" />
     <axis xyz="1 0 0"/>
   </joint>
-
+  
   <gazebo reference="${namespace}/sonar${suffix}_link">
     <sensor type="ray" name="sonar${suffix}">
       <pose>0 0 0 0 0 0</pose>
@@ -76,15 +76,16 @@
           <stddev>${range_stddev}</stddev>
         </noise>
       </ray>
-      <plugin name="sonar${suffix}_controller" filename="libgazebo_ros_laser.so">
+      <plugin name="sonar${suffix}_controller" filename="libunderwater_sonar_ros_plugin.so">
         <topicName>${topic}</topicName>
         <frameName>sonar${suffix}_link</frameName>
       </plugin>
       <!-- TODO: Separate switchable sonar version in another macro -->
-      <plugin name="switchable_sonar{suffix}_ros_interface" filename="libuuv_gazebo_ros_switchable_gpu_ray_sensor.so">
+	  <!-- <plugin name="switchable_sonar{suffix}_ros_interface" filename="libuuv_gazebo_ros_switchable_gpu_ray_sensor.so">
           <namespace>${namespace}</namespace>
           <input_topic>${topic}</input_topic>
-      </plugin>
+	  </plugin>
+	  -->
     </sensor>
   </gazebo>
   </xacro:macro>

--- a/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
+++ b/smarc_sensor_plugins/smarc_sensor_plugins_ros/urdf/sonar_snippets.xacro
@@ -16,6 +16,8 @@
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <!-- <plugin name="register_underwater_sonar_sensor" filename="libregister_underwater_sonar_sensor.so"/> -->
+
   <!-- Macro for a minimal collision block (for when you do not want collision block but gazebo needs one) -->
   <xacro:macro name="no_collision">
     <collision>
@@ -51,7 +53,7 @@
   </joint>
   
   <gazebo reference="${namespace}/sonar${suffix}_link">
-    <sensor type="ray" name="sonar${suffix}">
+    <sensor type="underwater_sonar" name="sonar${suffix}">
       <pose>0 0 0 0 0 0</pose>
       <visualize>false</visualize>
       <retro>true</retro>

--- a/smarc_worlds/launch/pipe_following.launch
+++ b/smarc_worlds/launch/pipe_following.launch
@@ -13,6 +13,7 @@
         <arg name="headless" value="false"/>
         <arg name="debug" value="false"/>
         <arg name="verbose" value="true"/>
+		<arg name="extra_gazebo_args" value="-s libregister_underwater_sonar_sensor.so"/>
     </include>
 
     <node name="publish_world_models"

--- a/smarc_worlds/launch/pipe_following.launch
+++ b/smarc_worlds/launch/pipe_following.launch
@@ -23,8 +23,8 @@
         <rosparam subst_value="true">
             meshes:
                 heightmap:
-                    mesh: package://uuv_descriptions/world_models/sand_heightmap/meshes/heightmap.dae
-                    model: sand_heightmap
+                    mesh: package://smarc_worlds/world_models/sand_heightmap_pipe/meshes/heightmap.dae
+                    model: sand_heightmap_pipe
                 seafloor:
                     plane: [2000, 2000, 0.1]
                     pose:

--- a/smarc_worlds/launch/skytteren.launch
+++ b/smarc_worlds/launch/skytteren.launch
@@ -12,6 +12,7 @@
         <arg name="headless" value="false"/>
         <arg name="debug" value="false"/>
         <arg name="verbose" value="true"/>
+		<arg name="extra_gazebo_args" value="-s libregister_underwater_sonar_sensor.so"/>
     </include>
 
     <!-- <node name="publish_world_models"

--- a/smarc_worlds/launch/sonar_intensities.launch
+++ b/smarc_worlds/launch/sonar_intensities.launch
@@ -13,6 +13,7 @@
         <arg name="headless" value="false"/>
         <arg name="debug" value="false"/>
         <arg name="verbose" value="true"/>
+		<arg name="extra_gazebo_args" value="-s libregister_underwater_sonar_sensor.so"/>
     </include>
 
     <node name="publish_world_models"

--- a/smarc_worlds/world_models/sand_heightmap_pipe/model.sdf
+++ b/smarc_worlds/world_models/sand_heightmap_pipe/model.sdf
@@ -19,17 +19,18 @@
     <static>true</static>
     <link name="link">
       <collision name="ground">
-        <pose>0 0 0 1.57 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
-          <mesh><uri>model://sand_heightmap_pipe/meshes/heightmap_pipe.dae</uri></mesh>
+          <mesh><uri>model://sand_heightmap_pipe/meshes/heightmap.dae</uri></mesh>
         </geometry>
+		<laser_retro>50</laser_retro>
       </collision>
 
       <visual name="ground_sand">
         <cast_shadows>true</cast_shadows>
-        <pose>0 0 0 1.57 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
-          <mesh><uri>model://sand_heightmap_pipe/meshes/heightmap_pipe.dae</uri></mesh>
+          <mesh><uri>model://sand_heightmap_pipe/meshes/heightmap.dae</uri></mesh>
         </geometry>
         <material>
           <script>
@@ -37,6 +38,7 @@
             <name>UUVSimulator/SandAndStones</name>
           </script>
         </material>
+		<laser_retro>50</laser_retro>
       </visual>
     </link>
   </model>

--- a/smarc_worlds/worlds/pipe_following.world
+++ b/smarc_worlds/worlds/pipe_following.world
@@ -69,7 +69,7 @@
 
     <!-- Heightmap -->
     <include>
-      <uri>model://sand_heightmap</uri>
+      <uri>model://sand_heightmap_pipe</uri>
       <pose>0 0 -95 0 0 0</pose>
     </include>
 


### PR DESCRIPTION
This pull request adds a new sensor, `underwater_sonar`, that returns intensities that CAN be based on a sonar equation. Currently, we can factor in material, distance through the water and incidence angle. The sensor also returns the names of the gazebo scene entities that the rays intersect, in `/namespace/scan_entities`. It is intended that we will use this information to include target strengths for more complex objects than the currently supported planes.

This PR changes the default sonar in the `small_smarc_auv` model.